### PR TITLE
Feature/ralph-hashtag - Introduce Hashtag UI and DB structure

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -94,3 +94,9 @@ button{
 	background-color: #FFFFFF; 
 	padding: 10px;
 }
+
+
+#tagButtonGroup{
+	float:right;
+	margin: 0px 0px 0px 10px;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -112,3 +112,7 @@ button{
 	float:right;
 	margin: 0px 0px 0px 10px;
 }
+
+#popularTagButtonGroup{
+	margin: 0px 0px 0px 0px;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -70,12 +70,24 @@ button{
 
 #toTop{
 	position: fixed;
-	bottom: 95px;
-	right: 40px;
+	bottom: 60px;
+	right: 30px;
 	cursor: pointer;
-	display: none;
 }
-#toTop .fa {margin-right: 5px;}
+
+#toTop .fa {margin-right: 3px;}
+
+#submitButton{
+	margin: 0px 5px 5px 0px;
+}
+
+#sortButton{
+	margin: 0px 5px 5px 0px;
+}
+
+#replyButton{
+	margin: 0px 0px 5px 10px;
+}
 
 #questionsContainer{
 	padding-top: 1.5em;

--- a/js/controllers/todoCtrl.js
+++ b/js/controllers/todoCtrl.js
@@ -52,7 +52,7 @@ var queryTags = echoRefTags.orderByChild("used");
 
 $scope.todos = $firebaseArray(queryQuestions);
 $scope.todosReplies = $firebaseArray(queryReplies);
-$scope.todosTags = $firebaseArray(queryReplies);
+$scope.todosTags = $firebaseArray(queryTags);
 
 $scope.editedTodo = null;
 
@@ -100,6 +100,12 @@ $scope.$watchCollection('todosReplies', function () {
 }, true);
 
 
+// pre-processing for collection - Tags
+$scope.$watchCollection('todosReplies', function () {
+
+}, true);
+
+
 
 // Post question
 $scope.doAsk = function () {
@@ -127,9 +133,23 @@ $scope.doAsk = function () {
 	// concatenate hasthags from head and desc
 	var tags = tagsHead.concat(tagsDesc);
 	
-
+	tags.forEach(function(part, index) {
+		window.alert('Before: tagCurrent=' + tags[index]);
+		tags[index] = part.toLowerCase();
+		window.alert('After: tagCurrent=' + tags[index]);
+	});
 	
-	// add to DB array
+	// all letters of tags are lowercase
+	/*
+	tags.forEach(function (tagCurrent) {
+		window.alert('Before: tagCurrent=' + tagCurrent);
+		tagCurrent = tagCurrent.toLowerCase();
+		tags.$save(tagCurrent);
+		window.alert('After: tagCurrent=' + tagCurrent);
+	});
+	*/
+	
+	// add to question array
 	$scope.todos.$add({
 		wholeMsgReply: '',
 		head: head,
@@ -145,6 +165,40 @@ $scope.doAsk = function () {
 	// remove the posted question in the input
 	$scope.input.head = '';
 	$scope.input.desc = '';
+	
+	// add to tags array
+	
+	// iterate current tags
+	tags.forEach(function (tagCurrent) {
+		var isNew = 1;
+		window.alert('in tags.forEach for tagCurrent=' + tagCurrent + ' with isNew=' + isNew);
+		
+		//tagCurrent.equals(tagStored.name)
+		// iterate database tags
+		$scope.todosTags.forEach(function(tagStored) {
+			window.alert("in todosTags.forEach for tagStored.name=" + tagStored.name);
+			if(tagCurrent ==tagStored.name) { 
+				window.alert("entered if.");
+				// increase counter if tag already exists
+				tagStored.used = tagStored.used + 1;
+				$scope.todosTags.$save(tagStored);
+				isNew = 0;
+				//break; // TODO: find a break in javascript
+				window.alert("isNew=0");
+			}
+			window.alert("passed if.");
+		});
+		// add tag if it is new
+		window.alert('Currently, isNew=' + isNew);
+		if(isNew == 1) {
+			$scope.todosTags.$add({
+				name: tagCurrent,
+				used: 1
+			});
+			window.alert("isNew=1");
+		}		
+	});	
+
 };
 
 
@@ -166,7 +220,7 @@ $scope.doReply = function (todo) {
 	// TODO: Seems to be superfluous if not trusting the desc as HTML anyway
 	//var desc = $scope.XssProtection(newTodo);
 	
-	// add to DB array
+	// add to reply array
 	$scope.todosReplies.$add({
 		desc: newTodo,
 		timestamp: new Date().getTime(),
@@ -346,10 +400,6 @@ $scope.addTagToSearch = function(tag) {
 		var Msg = tag;
 	}
 	$scope.input = {head: Msg};
-}
-
-$scope.addTagToDatabase = function(tag) {
-
 }
 
 $scope.XssProtection = function($string) {

--- a/js/controllers/todoCtrl.js
+++ b/js/controllers/todoCtrl.js
@@ -79,14 +79,17 @@ $scope.$watchCollection('todos', function () {
 		
 		// TODO: create tags for head and desc
 		// see http://www.w3schools.com/jsref/jsref_concat_array.asp
-		//var tagsDesc = todo.desc.match(/#\w+/g);
-		//var tagsHead = todo.head.match(/#\w+/g);
-		//todo.tags = tagsHead.concat(tagsDesc); 
 		
-		todo.tags = todo.head.match(/#\w+/g); // find all # plus the following word characters);
+		var tagsHead = todo.head.match(/#\w+/g);
+		if (tagsHead == null) 	// no match found
+			tagsHead = [];	// intialize to avoid error using concat
 		
-		// changes before here will be stored in DB
-		// changes after will not
+		var tagsDesc = todo.desc.match(/#\w+/g);
+		if (tagsDesc == null) 	// no match found
+			tagsDesc = [];	// intialize to avoid error using concat
+		
+		todo.tags = tagsHead.concat(tagsDesc); 
+		
 		$scope.todos.$save(todo);
 		
 	});
@@ -158,11 +161,11 @@ $scope.doReply = function (todo) {
 	$scope.todos.$save(todo);
 	
 	// TODO: Seems to be superfluous if not trusting the desc as HTML anyway
-	var desc = $scope.XssProtection(newTodo);
+	//var desc = $scope.XssProtection(newTodo);
 	
 	// add to DB array
 	$scope.todosReplies.$add({
-		desc: desc,
+		desc: newTodo,
 		timestamp: new Date().getTime(),
 		order: 0,
 		parentID: todo.$id,
@@ -328,6 +331,20 @@ angular.element($window).bind("scroll", function() {
 		$scope.$apply();
 	}
 });
+
+$scope.addTagToSearch = function($tag) {
+	try{
+		if ($scope.input.head.trim())
+			var Msg = $scope.input.head.trim() + " " +$tag;
+		else
+			var Msg = $tag;
+	}
+	catch(e){
+		var Msg = $tag;
+	}
+	$scope.input = {head: Msg};
+}
+
 
 $scope.XssProtection = function($string) {
     //var filteredMsg = "<pre>";

--- a/js/controllers/todoCtrl.js
+++ b/js/controllers/todoCtrl.js
@@ -49,10 +49,13 @@ var echoRefTags = new Firebase(urlTags);
 var queryQuestions = echoRefQuestions.orderByChild("order");	// TODO: adapt once removing the 'order' attribute
 var queryReplies = echoRefReplies.orderByChild("order");
 var queryTags = echoRefTags.orderByChild("used");
+var queryPopularTags = echoRefTags.orderByChild("used").limitToLast(5);
 
 $scope.todos = $firebaseArray(queryQuestions);
 $scope.todosReplies = $firebaseArray(queryReplies);
 $scope.todosTags = $firebaseArray(queryTags);
+$scope.todosPopularTags = $firebaseArray(queryPopularTags);
+// TODO: find a way to invert order. todosPopularTags.reverse() does not work...
 
 $scope.editedTodo = null;
 
@@ -62,6 +65,9 @@ if($scope.predicate == undefined) {
 	$scope.predicateText = 'Date';
 	$scope.reverse = true;
 }
+
+
+
 
 
 // pre-processing for collection - Questions
@@ -133,21 +139,10 @@ $scope.doAsk = function () {
 	// concatenate hasthags from head and desc
 	var tags = tagsHead.concat(tagsDesc);
 	
+	// convert all letters of tags to lowercase
 	tags.forEach(function(part, index) {
-		window.alert('Before: tagCurrent=' + tags[index]);
 		tags[index] = part.toLowerCase();
-		window.alert('After: tagCurrent=' + tags[index]);
 	});
-	
-	// all letters of tags are lowercase
-	/*
-	tags.forEach(function (tagCurrent) {
-		window.alert('Before: tagCurrent=' + tagCurrent);
-		tagCurrent = tagCurrent.toLowerCase();
-		tags.$save(tagCurrent);
-		window.alert('After: tagCurrent=' + tagCurrent);
-	});
-	*/
 	
 	// add to question array
 	$scope.todos.$add({
@@ -171,31 +166,30 @@ $scope.doAsk = function () {
 	// iterate current tags
 	tags.forEach(function (tagCurrent) {
 		var isNew = 1;
-		window.alert('in tags.forEach for tagCurrent=' + tagCurrent + ' with isNew=' + isNew);
+		//window.alert('in tags.forEach for tagCurrent=' + tagCurrent + ' with isNew=' + isNew);
 		
-		//tagCurrent.equals(tagStored.name)
 		// iterate database tags
 		$scope.todosTags.forEach(function(tagStored) {
-			window.alert("in todosTags.forEach for tagStored.name=" + tagStored.name);
+			//window.alert("in todosTags.forEach for tagStored.name=" + tagStored.name);
 			if(tagCurrent ==tagStored.name) { 
-				window.alert("entered if.");
+				//window.alert("entered if.");
 				// increase counter if tag already exists
 				tagStored.used = tagStored.used + 1;
 				$scope.todosTags.$save(tagStored);
 				isNew = 0;
 				//break; // TODO: find a break in javascript
-				window.alert("isNew=0");
+				//window.alert("isNew=0");
 			}
-			window.alert("passed if.");
+			//window.alert("passed if.");
 		});
 		// add tag if it is new
-		window.alert('Currently, isNew=' + isNew);
+		//window.alert('Currently, isNew=' + isNew);
 		if(isNew == 1) {
 			$scope.todosTags.$add({
 				name: tagCurrent,
 				used: 1
 			});
-			window.alert("isNew=1");
+			//window.alert("isNew=1");
 		}		
 	});	
 

--- a/js/controllers/todoCtrl.js
+++ b/js/controllers/todoCtrl.js
@@ -338,7 +338,7 @@ angular.element($window).bind("scroll", function() {
 $scope.addTagToSearch = function(tag) {
 	try{
 		if ($scope.input.head.trim())
-			var Msg = $scope.input.head.trim() + " " +$tag;
+			var Msg = $scope.input.head.trim() + " " + tag;
 		else
 			var Msg = tag;
 	}
@@ -353,7 +353,6 @@ $scope.addTagToDatabase = function(tag) {
 }
 
 $scope.XssProtection = function($string) {
-    //var filteredMsg = "<pre>";
 	var filteredMsg = '';
     var inHashtag = false;
     for (var i = 0; i < $string.length; ++i) {
@@ -374,7 +373,6 @@ $scope.XssProtection = function($string) {
 	    	filteredMsg+=ch;
 		}
     }
-    //filteredMsg+="</pre>";
     return filteredMsg;
 };
 

--- a/js/controllers/todoCtrl.js
+++ b/js/controllers/todoCtrl.js
@@ -39,18 +39,20 @@ var firebaseURL = "https://cmkquestionsdb.firebaseio.com/";
 
 // create variables for firebase DB
 $scope.roomId = roomId;
-var url = firebaseURL + roomId + "/questions/";
+var urlQuestions = firebaseURL + roomId + "/questions/";
 var urlReplies = firebaseURL + roomId + "/replies/";
-var echoRef = new Firebase(url);
+var urlTags = firebaseURL + roomId + "/tags/";
+var echoRefQuestions = new Firebase(urlQuestions);
 var echoRefReplies = new Firebase(urlReplies);
+var echoRefTags = new Firebase(urlTags);
 
-var query = echoRef.orderByChild("order");
+var queryQuestions = echoRefQuestions.orderByChild("order");	// TODO: adapt once removing the 'order' attribute
 var queryReplies = echoRefReplies.orderByChild("order");
+var queryTags = echoRefTags.orderByChild("used");
 
-// TODO: Should we limit?
-//.limitToFirst(1000);
-$scope.todos = $firebaseArray(query);
+$scope.todos = $firebaseArray(queryQuestions);
 $scope.todosReplies = $firebaseArray(queryReplies);
+$scope.todosTags = $firebaseArray(queryReplies);
 
 $scope.editedTodo = null;
 
@@ -76,20 +78,7 @@ $scope.$watchCollection('todos', function () {
 		if (todo.completed === false) {
 			remaining++;
 		}
-		
-		// TODO: create tags for head and desc
-		// see http://www.w3schools.com/jsref/jsref_concat_array.asp
-		
-		var tagsHead = todo.head.match(/#\w+/g);
-		if (tagsHead == null) 	// no match found
-			tagsHead = [];	// intialize to avoid error using concat
-		
-		var tagsDesc = todo.desc.match(/#\w+/g);
-		if (tagsDesc == null) 	// no match found
-			tagsDesc = [];	// intialize to avoid error using concat
-		
-		todo.tags = tagsHead.concat(tagsDesc); 
-		
+
 		$scope.todos.$save(todo);
 		
 	});
@@ -126,6 +115,20 @@ $scope.doAsk = function () {
 		desc = descInput;
 	}
 	
+	
+	// extract hashtags from questions
+	var tagsHead = head.match(/#\w+/g);
+	if (tagsHead == null)
+		tagsHead = [];	// intialize to avoid error using concat
+	
+	var tagsDesc = desc.match(/#\w+/g);
+	if (tagsDesc == null)
+		tagsDesc = [];
+	// concatenate hasthags from head and desc
+	var tags = tagsHead.concat(tagsDesc);
+	
+
+	
 	// add to DB array
 	$scope.todos.$add({
 		wholeMsgReply: '',
@@ -133,7 +136,7 @@ $scope.doAsk = function () {
 		desc: desc,
 		completed: false,
 		timestamp: new Date().getTime(),
-		tags: "...",
+		tags: tags,
 		like: 0,
 		dislike: 0,
 		order: 0,
@@ -332,19 +335,22 @@ angular.element($window).bind("scroll", function() {
 	}
 });
 
-$scope.addTagToSearch = function($tag) {
+$scope.addTagToSearch = function(tag) {
 	try{
 		if ($scope.input.head.trim())
 			var Msg = $scope.input.head.trim() + " " +$tag;
 		else
-			var Msg = $tag;
+			var Msg = tag;
 	}
 	catch(e){
-		var Msg = $tag;
+		var Msg = tag;
 	}
 	$scope.input = {head: Msg};
 }
 
+$scope.addTagToDatabase = function(tag) {
+
+}
 
 $scope.XssProtection = function($string) {
     //var filteredMsg = "<pre>";

--- a/question.html
+++ b/question.html
@@ -60,12 +60,6 @@
 	</div>
 </nav>
 
-<!--
-<a ng-class="{selected: location.path() == '/newechos'}" class="btn btn-primary" href="#/newechos">New Echos</a>
-<a ng-class="{selected: location.path() == '/tags'}" class="btn btn-success" href="#/tags">Tags</a>
-<a ng-class="{selected: location.path() == '/users'}" class="btn btn-info" href="#/users">Users</a>
-<a ng-class="{selected: location.path() == '/about'}" class="btn btn-warning" href="#/about">About</a>
--->
 <div class="container">
 	<div class="jumbotron">
 		<h1 style="font-family: 'Bubblegum Sans', cursive">Questions for {{roomId}}?</h1>
@@ -123,7 +117,7 @@
 	<!-- Question Bounder -->
 	<div id="questionBoundary" class="list-group">
 		<!-- Iterate Questions -->
-		<div class="media" ng-repeat="todo in todos | filter:input | questionFilter:maxQuestion | orderBy:predicate:reverse" ng-class="{completed: todo.completed, editing: todo == editedTodo}">
+		<div class="media" ng-repeat="todo in todos | filter:input.head |filter:input.desc | questionFilter:maxQuestion | orderBy:predicate:reverse" ng-class="{completed: todo.completed, editing: todo == editedTodo}">
 			<!-- Display Avatar -->
 			<div class="media-left">
 				<a href="#">
@@ -139,8 +133,8 @@
 				</h4>
 				<div style="font-family: 'Merriweather Sans', sans-serif; font-style: italic">{{todo.desc}}<br></div>
 				<small style="margin-top:5px; color:#848484">
-					<!-- <em>created: {{ todo.timestamp | date:'medium' }}</em> -->
 					<em>Created: <time title="{{ todo.timestamp | date:'medium'}}" am-time-ago="todo.timestamp"</time></em>
+					
 				</small>
 				<div>
 					<button class="btn btn-success btn-xs glyphicon glyphicon-thumbs-up" ng-click="doLike(todo)" ng-disabled="$storage[todo.$id]">Like<span class="badge">{{todo.like}}</span></button>
@@ -149,6 +143,9 @@
 					<button ng-show="isAdmin" class="btn btn-default btn-xs glyphicon glyphicon-check" ng-click="toggleCompleted(todo)">Toggle Completed</button>
 					&nbsp;
 					<button ng-show="isAdmin" class="btn btn-default btn-xs glyphicon glyphicon-trash" aria-hidden="true" ng-click="removeTodo(todo)">Del</button>
+					<div class="btn-group" id="tagButtonGroup" >
+						<button class="btn btn-primary btn-xs glyphicon glyphicon-tag" ng-repeat="tag in todo.tags" ng-click="addTagToSearch(tag)">{{tag.substr(1)}}</button>
+					</div>
 				</div>
 
 				<div class="list-group" style="background-color: #F5F5F5;">

--- a/question.html
+++ b/question.html
@@ -19,6 +19,7 @@
 
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"> 
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 
 	<!-- need this for comlted ones. TODO: can I do this in bootstrap -->
 	<link rel="stylesheet" href="css/main.css">
@@ -83,22 +84,18 @@
 	
 	
 	<form id="todo-form" ng-submit="doAsk()" class="ng-pristine ng-invalid ng-invalid-required ng-valid-maxlength ng-valid-minlength">
+		<div class = "col-md-8">
+			<input type="text" id="questionTitleText" class="form-control ng-pristine ng-invalid ng-invalid-required ng-valid-maxlength ng-touched" ng-model="input.head" placeholder="Enter Question Title" autofocus="" required="" maxlength="128" title="A title is required">
 
-		<div class = "col-md-10">
-
-				<input type="text" id="questionTitleText" class="form-control ng-pristine ng-invalid ng-invalid-required ng-valid-maxlength ng-touched" ng-model="input.head" placeholder="Enter Question Title" autofocus="" required="" maxlength="128" title="A title is required">
-
-				<textarea type="text" id="new-todo" class="form-control ng-pristine ng-invalid ng-invalid-required ng-valid-maxlength ng-untouched" placeholder="Enter Question Text or Search Questions" ng-model="input.desc" ng-maxlength="1024" title="Less than 1024 characters"></textarea>
-		
+			<textarea type="text" id="new-todo" class="form-control ng-pristine ng-invalid ng-invalid-required ng-valid-maxlength ng-untouched" placeholder="Enter Question Text or Search Questions" ng-model="input.desc" ng-maxlength="1024" title="Less than 1024 characters"></textarea>
 		</div>
 		<div class = "col-md-2">	
-		
 			<span class="form-group-btn">
-				<button class="btn btn-default btn-primary btn-lg" type="submit">Ask!</button>
+				<button id="submitButton" class="btn btn-default btn-primary btn-lg btn-block" type="submit">Ask!</button>
 			</span>
 
 			<div class="dropdown">
-				<button class="btn btn-default btn-primary dropdown-toggle" type="button" id="sortingDropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">Sort by: {{predicateText}} <span class="caret"></span>
+				<button id="sortButton" class="btn btn-default btn-default btn-block dropdown-toggle" type="button" id="sortingDropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">Sort by: {{predicateText}} <span class="caret"></span>
 				</button>
 				<ul class="dropdown-menu">
 					<li><a href="" ng-click="setSorting('-timestamp','Date')">Date</a></li>
@@ -113,7 +110,8 @@
 
 
 
-<div id="questionsContainer" class="container">
+<div id="questionsContainer" class="container"> 
+	<div class = "col-md-10">
 	<!-- Question Bounder -->
 	<div id="questionBoundary" class="list-group">
 		<!-- Iterate Questions -->
@@ -144,7 +142,7 @@
 					&nbsp;
 					<button ng-show="isAdmin" class="btn btn-default btn-xs glyphicon glyphicon-trash" aria-hidden="true" ng-click="removeTodo(todo)">Del</button>
 					<div class="btn-group" id="tagButtonGroup" >
-						<button class="btn btn-primary btn-xs glyphicon glyphicon-tag" ng-repeat="tag in todo.tags" ng-click="addTagToSearch(tag)">{{tag.substr(1)}}</button>
+						<button class="btn btn-default btn-xs glyphicon glyphicon-tag" ng-repeat="tag in todo.tags" ng-click="addTagToSearch(tag)">{{tag.substr(1)}}</button>
 					</div>
 				</div>
 
@@ -176,23 +174,25 @@
 					</div>
 				</div>
 				<div class="input-group" style="margin-left:50px">
-						<textarea type="text" id="new-todo-reply" class="form-control" placeholder="Have Answer? Save their day!" ng-model="todo.wholeMsgReply">
+						<textarea type="text" id="new-todo-reply" class="form-control" placeholder="Have an Answer? Save their day!" ng-model="todo.wholeMsgReply">
 						</textarea>
 						<span class="input-group-btn">
-							<button class="btn btn-default" type="button" ng-click="doReply(todo)">Reply!</button>
+							<button id="replyButton" class="btn btn-default" type="button" ng-click="doReply(todo)">Reply!</button>
 						</span>
 				</div>
 			</div>
 		</div>
 	</div>
 	<hr style="border-color: #ff8c00">
+	</div>
 </div>
-<!--
-<div id="toTop" class="btn btn-info"><span class="fa fa-arrow-up">Back to Top</span></div>
-<button ng-hide="totalCount<=maxQuestion"
-class="pull-right btn btn-default glyphicon glyphicon-arrow-down"
-type="button" ng-click="increaseMax()"> Show more</button>
--->
+
+<!-- static toTop button and Show More questions button-->
+<div id="toTop" class="btn btn-default" ng-click="toTop()"><span class="fa fa-arrow-up">To Top</span></div>
+<button ng-hide="totalCount<=maxQuestion" class="pull-right btn btn-default glyphicon glyphicon-arrow-down" type="button" ng-click="increaseMax()"> Show More
+</button>
+
+
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 <script src="js/bootstrap.min.js"></script>

--- a/question.html
+++ b/question.html
@@ -84,11 +84,13 @@
 	
 	
 	<form id="todo-form" ng-submit="doAsk()" class="ng-pristine ng-invalid ng-invalid-required ng-valid-maxlength ng-valid-minlength">
+		<!-- Question Title and Text Fields -->
 		<div class = "col-md-8">
 			<input type="text" id="questionTitleText" class="form-control ng-pristine ng-invalid ng-invalid-required ng-valid-maxlength ng-touched" ng-model="input.head" placeholder="Enter Question Title" autofocus="" required="" maxlength="128" title="A title is required">
 
 			<textarea type="text" id="new-todo" class="form-control ng-pristine ng-invalid ng-invalid-required ng-valid-maxlength ng-untouched" placeholder="Enter Question Text or Search Questions" ng-model="input.desc" ng-maxlength="1024" title="Less than 1024 characters"></textarea>
 		</div>
+		<!-- Question Buttons -->
 		<div class = "col-md-2">	
 			<span class="form-group-btn">
 				<button id="submitButton" class="btn btn-default btn-primary btn-lg btn-block" type="submit">Ask!</button>
@@ -104,7 +106,15 @@
 					<li><a href="" ng-click="setSorting('-dislike','Dislikes')">Dislikes</a></li>
 				</ul>
 			</div>
-		</div>		
+		</div>	
+		<!-- Tag Bar -->
+		<div class = "col-md-10">	
+			<div class="btn-group" id="popularTagButtonGroup" >
+				<!-- use reverse() since these are the most popular tags in ascending order. -->
+				<button class="btn btn-default btn-xs glyphicon glyphicon-tag" ng-repeat="tag in todosPopularTags" ng-click="addTagToSearch(tag.name)">{{tag.name.substr(1)}}</button>
+			</div>
+		</div>
+			
 	</form>
 </div>
 


### PR DESCRIPTION
This PR tries to fulfill the hashtag feature as described on slack. 
At the same time it fixes #24 (hashtags are now created from head and desc of a question).

**First** key feature:
For every question, the used hashtags are displayed
![bildschirmfoto 2015-11-19 um 12 48 58](https://cloud.githubusercontent.com/assets/1174752/11262584/fa82768a-8ebb-11e5-9cff-6264ca6a4d4a.png)

**Second** key feature:
The most popular hashtags are displayed below the 'new question' box. 
![bildschirmfoto 2015-11-19 um 12 21 14](https://cloud.githubusercontent.com/assets/1174752/11262530/547c9270-8ebb-11e5-809e-56c4f36ff9aa.png)

**More** features:
- all tags are converted to lowercase.
- click a hashtag and it is added to the new question/search box
- thus, you can easily search for a hashtag by clicking on it
- Reintroduced the button 'to Top' which scrolls to top of page. The button makes sense now since when you click on a hashtag, you want to go back to the 'new question' box.
- Slight restructured of the buttons 'Ask!' and 'Sort by:'

See all the new buttons:
![1](https://cloud.githubusercontent.com/assets/1174752/11262664/cef762d6-8ebc-11e5-9050-680ba4692ecf.png)

Minor issues:
I will create two minor issues once the PR is accepted. None of them causes errors or breaks the functionality.
The first one is the order of the most popular tags: The bar below the question box displays the most popular hashtags from right to left instead of from left to right.
The second one is some issue for special hashtag combinations. 
